### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "magi-1"
+description = ""
+version = "1.0.0"
+license = {file = "LICENSE"}
+dependencies = ["accelerate==0.32.1", "beautifulsoup4==4.13.4", "debugpy==1.8.14", "diffusers==0.29.2", "einops>=0.6.0", "ffmpeg-python", "flash-attn==2.4.2", "flashinfer-python==0.2.0.post2 --extra-index-url https://flashinfer.ai/whl/cu124/torch2.4/", "ftfy==6.2.0", "gpustat==1.1.1", "imageio==2.34.0", "imageio[ffmpeg]", "matplotlib==3.10.1", "numpy==1.26.4", "protobuf==5.28.3", "rich==14.0.0", "sentencepiece==0.2.0", "timm==1.0.15", "torchdiffeq==0.2.4", "transformers==4.42.3"]
+
+[project.urls]
+Repository = "https://github.com/ZHANGWENTAI/MAGI-1"
+#  Used by Comfy Registry https://registry.comfy.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "MAGI-1"
+Icon = ""
+includes = []


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

The registry is already integrated with ComfyUI-Manager, and we want it to be the default place users install nodes from eventually. We do a security-scan of every node to improve safety. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

- The documentation scaffolding? You can just add the example markdown [here](https://docs.comfy.org/custom-nodes/help_page#setup) into web/docs/MyNode.md

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!